### PR TITLE
Better Drizzle Colors

### DIFF
--- a/app/javascripts/tiles/downloads.jsx
+++ b/app/javascripts/tiles/downloads.jsx
@@ -323,8 +323,20 @@ var DownloadsTile = React.createClass({
     } else {
       chart = <Line ref='downloads' data={self.state.data} options={{
         legend: {display: false},
-        title: {display: true, text: "Monthly Downloads (until last month)"},
+        title: {display: true, text: "Monthly Downloads (until last month)", fontColor: "#383838"},
         animation: false,
+        scales: {
+          xAxes: [{
+            ticks: {
+              fontColor: "#383838"
+            }
+          }],
+          yAxes: [{
+            ticks: {
+              fontColor: "#383838"
+            }
+          }]
+        },
         tooltips: {
           displayColors: false,
           callbacks: {

--- a/app/javascripts/tiles/stargazers.jsx
+++ b/app/javascripts/tiles/stargazers.jsx
@@ -143,7 +143,7 @@ var StargazersTile = React.createClass({
     var colors = [
       "#3fe0c5",
       "#e4a663",
-      "#e911bd",
+      "#f069d6",
       "#b86bff"
     ];
 

--- a/app/stylesheets/dashboard.scss
+++ b/app/stylesheets/dashboard.scss
@@ -82,10 +82,10 @@
 }
 
 .is-drizzle {
-  background: #e911bd;
+  background: #f069d6;
 
   &.has-border {
     background: #33262a;
-    border: 2px solid #e911bd;
+    border: 2px solid #f069d6;
   }
 }


### PR DESCRIPTION
The colors on https://truffleframework.com/dashboard are very hard to read for drizzle. This PR uses the palest color in our color palette (in the style guidelines) for the pink. I also darkened the text on the charts to be more legible. See the below image

![image](https://user-images.githubusercontent.com/549323/53133875-ce7e2d00-3542-11e9-92f6-69d8965d618b.png)
