### PR TITLE
moving the github access token to request header

### DIFF
--- a/app/javascripts/tiles/stargazers.jsx
+++ b/app/javascripts/tiles/stargazers.jsx
@@ -42,9 +42,10 @@ var StargazersTile = React.createClass({
     }
 
     axios.request({
-      url: "https://api.github.com/repos/" + project + "/stargazers?access_token=" + this.state.access_token,
+      url: "https://api.github.com/repos/" + project + "/stargazers",
       headers: {
-        Accept: "application/vnd.github.v3.star+json"
+        Accept: "application/vnd.github.v3.star+json",
+        Authorization: "token " + this.state.access_token
       }
     }).then(function(response) {
       processResponse(response);
@@ -59,9 +60,10 @@ var StargazersTile = React.createClass({
 
       while (current <= last) {
         requests.push(axios.request({
-          url: "https://api.github.com/repos/" + project + "/stargazers?page=" + current + "&access_token=" + self.state.access_token,
+          url: "https://api.github.com/repos/" + project + "/stargazers?page=" + current,
           headers: {
-            Accept: "application/vnd.github.v3.star+json"
+            Accept: "application/vnd.github.v3.star+json",
+            Authorization: "token " + self.state.access_token
           }
         }));
 


### PR DESCRIPTION
Should be pretty self explanatory :) For reference more notes at the following: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/